### PR TITLE
fix: make build work on macos

### DIFF
--- a/zig.go
+++ b/zig.go
@@ -11,6 +11,7 @@ import (
 
 /*
 #cgo linux LDFLAGS: -lz
+#cgo darwin LDFLAGS: -lz
 #cgo windows LDFLAGS: -lz -lws2_32
 #include "zig.h"
 */


### PR DESCRIPTION
Otherwise the build will fail with errors like `ld: symbol(s) not found for architecture x86_64`